### PR TITLE
Add Imgur image codes for Markdown, BBCode, and HTML

### DIFF
--- a/src/tools/imgupload/imguploadermanager.cpp
+++ b/src/tools/imgupload/imguploadermanager.cpp
@@ -68,3 +68,17 @@ const QString& ImgUploaderManager::url()
 {
     return m_urlString;
 }
+
+QString ImgUploaderManager::generateImageCode(const QString& format,
+                                              const QString& imageUrl)
+{
+    if (format == "markdown") {
+        return "![](" + imageUrl + ")";
+    } else if (format == "bbcode") {
+        return "[img]" + imageUrl + "[/img]";
+    } else if (format == "html") {
+        return "<img src=\"" + imageUrl + "\" />";
+    } else {
+        return imageUrl; 
+    } 
+}

--- a/src/tools/imgupload/imguploadermanager.h
+++ b/src/tools/imgupload/imguploadermanager.h
@@ -25,6 +25,8 @@ public:
 
     const QString& url();
     const QString& uploaderPlugin();
+    QString ImgUploaderManager::generateImageCode(const QString& format,
+                                                  const QString& imageUrl);
 
 private:
     void init();

--- a/src/tools/imgupload/imguploadertool.cpp
+++ b/src/tools/imgupload/imguploadertool.cpp
@@ -2,10 +2,25 @@
 // SPDX-FileCopyrightText: 2017-2019 Alejandro Sirgo Rica & Contributors
 
 #include "imguploadertool.h"
+#include "imguploadermanager.h"
+#include <QInputDialog>
+#include <QComboBox>
+#include <QVBoxLayout>
+#include <QMessageBox>
+#include <QTextEdit>
 
 ImgUploaderTool::ImgUploaderTool(QObject* parent)
   : AbstractActionTool(parent)
-{}
+{
+    auto m_formatComboBox = new QComboBox();
+    m_formatComboBox->addItem("Markdown");
+    m_formatComboBox->addItem("BBCode");
+    m_formatComboBox->addItem("HTML");
+    m_formatComboBox->addItem("URL");
+
+    QVBoxLayout* layout = new QVBoxLayout();
+    layout->addWidget(m_formatComboBox);
+}
 
 bool ImgUploaderTool::closeOnButtonPressed() const
 {
@@ -44,4 +59,40 @@ void ImgUploaderTool::pressed(CaptureContext& context)
     emit requestAction(REQ_CAPTURE_DONE_OK);
     context.request.addTask(CaptureRequest::UPLOAD);
     emit requestAction(REQ_CLOSE_GUI);
+
+    bool ok;
+    QStringList formats;
+    formats << "markdown"
+            << "bbcode"
+            << "html"
+            << "url";
+    QString selectedFormat =
+      QInputDialog::getItem(nullptr,
+                            "Select Image Format",
+                            "Choose format for image URL:",
+                            formats,
+                            0,
+                            false,
+                            &ok);
+
+    if (ok && !selectedFormat.isEmpty()) {
+        ImgUploaderManager* uploaderManager = new ImgUploaderManager();
+        QString imageUrl =
+          uploaderManager
+            ->url();
+        QString imageCode =
+          uploaderManager->generateImageCode(selectedFormat, imageUrl);
+
+        QMessageBox msgBox;
+        msgBox.setWindowTitle("Generated Image Code");
+
+        auto* textEdit = new QTextEdit(&msgBox);
+        textEdit->setText(imageCode); 
+        textEdit->setReadOnly(
+          true); 
+        textEdit->setPlainText(imageCode); 
+
+        msgBox.layout()->addWidget(textEdit);
+        msgBox.exec();
+    }
 }


### PR DESCRIPTION
In ImgUploaderManager, I implemented the generateImageCode() function, which took in a given format option and URL, returning a newly formatted URL. The formats include Markdown, BBCode, and HTML code. 
In ImgUploaderTool, I expanded on pressed() by implementing a UI dropdown box for users to interact with and select a desired format. 
These changes enhance usability and allow users to more quickly convert the Imgur image links into versions that better integrate with code. The feature addresses Issue #3774.